### PR TITLE
Update pre-commit hooks and add tofu-scan

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-symlinks
 
   - repo: https://github.com/osinfra-io/pt-techne-pre-commit-hooks
-    rev: fe697ad1e9131053bd379a1ca110904f220612fd # frozen: v0.1.3
+    rev: bf174b5f94101025ee45458e820d7ad693e21df1 # frozen: v0.1.5
     hooks:
       - id: tofu-fmt
         verbose: true
@@ -25,4 +25,7 @@ repos:
         verbose: true
 
       - id: tofu-test
+        verbose: true
+
+      - id: tofu-scan
         verbose: true

--- a/tests/default.tftest.hcl
+++ b/tests/default.tftest.hcl
@@ -30,7 +30,7 @@ run "gke_fleet_host" {
   }
 
   variables {
-    project = "mock-project-host-project"
+    project                    = "mock-project-host-project"
     shared_vpc_host_project_id = "mock-vpc-host-project"
   }
 }
@@ -85,8 +85,8 @@ run "gke_fleet_member" {
   }
 
   variables {
-    gke_fleet_host_project_id = "mock-fleet-host-project"
-    project                   = "mock-project-member-project"
+    gke_fleet_host_project_id  = "mock-fleet-host-project"
+    project                    = "mock-project-member-project"
     shared_vpc_host_project_id = "mock-vpc-host-project"
   }
 }


### PR DESCRIPTION
Update pre-commit hooks:

- Bump `pt-techne-pre-commit-hooks` to v0.1.4
- Add `tofu-scan` hook for CIS benchmark scanning (GCP Foundation v3.0.0 + GKE v1.6.1)
- Pin all hook revisions to frozen commit SHAs