### PR TITLE
Restrict pull_request_target event types in Dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,6 +1,8 @@
 name: Dependabot Approve and Merge
 
-on: pull_request_target
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

The `pull_request_target` trigger runs with base repository privileges and has access to repository secrets. Without explicit event type filters, it fires on all default PR event types.

This PR adds explicit `types: [opened, synchronize, reopened]` to the trigger (which was already the implicit default). Making it explicit:
- Documents the intended trigger scope
- Reduces the attack surface surface by being explicit rather than relying on defaults
- Follows the principle of explicit over implicit

Existing security mitigations remain in place:
- `github.actor == 'dependabot[bot]'` guard in the reusable called workflow
- No PR head code is checked out or executed
- Privileged operations use a GitHub App token, not `GITHUB_TOKEN`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined the automated dependency update workflow by implementing explicit event trigger conditions for pull requests. This enhancement improves consistency and reliability when processing dependency-related pull requests, ensuring the automation responds appropriately to specific lifecycle events while maintaining system stability and operational consistency throughout the development process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-arche-google-kubernetes-engine/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->