### PR TITLE
Make google_service_account optional in namespaces variable

### DIFF
--- a/regional/onboarding/locals.tofu
+++ b/regional/onboarding/locals.tofu
@@ -7,5 +7,6 @@ locals {
       namespace       = k,
       service_account = v.google_service_account
     }
+    if v.google_service_account != null
   }
 }

--- a/regional/onboarding/main.tofu
+++ b/regional/onboarding/main.tofu
@@ -69,7 +69,7 @@ resource "kubernetes_role_binding_v1" "namespace_admins" {
 # https://search.opentofu.org/provider/hashicorp/kubernetes/latest/docs/resources/role_v1
 
 resource "kubernetes_role_v1" "namespace_admins" {
-  for_each = var.namespaces
+  for_each = { for k, v in var.namespaces : k => v if v.google_service_account != null }
 
   metadata {
     name      = "namespace-admin"

--- a/regional/onboarding/variables.tofu
+++ b/regional/onboarding/variables.tofu
@@ -3,11 +3,11 @@
 
 variable "namespaces" {
   default     = {}
-  description = "A map of namespaces with the Google service account used for the namespace administrator and whether Istio injection is enabled or disabled"
+  description = "A map of namespaces with an optional Google service account used for the namespace administrator and whether Istio injection is enabled or disabled. When google_service_account is null, the namespace-admin Role and RoleBinding are skipped."
 
   type = map(object({
     annotations                  = optional(map(string))
-    google_service_account       = string
+    google_service_account       = optional(string, null)
     istio_control_plane_clusters = optional(string)
     istio_injection              = optional(string, "disabled")
   }))

--- a/variables.tofu
+++ b/variables.tofu
@@ -15,9 +15,9 @@ variable "labels" {
 
 variable "namespaces" {
   default     = {}
-  description = "A map of namespaces with the Google service account used for the namespace administrator and whether Istio injection is enabled or disabled"
+  description = "A map of namespaces with an optional Google service account used for the namespace administrator and whether Istio injection is enabled or disabled"
   type = map(object({
-    google_service_account = string
+    google_service_account = optional(string, null)
     istio_injection        = optional(string, "disabled")
   }))
 }


### PR DESCRIPTION
## What

Makes `google_service_account` optional (`optional(string, null)`) in the `namespaces` variable for both the main module and the `regional/onboarding` module.

When `google_service_account` is `null`, the `namespace-admin` Role and RoleBinding are skipped — the namespace is still created with the correct Istio injection label and the Workload Identity Kubernetes service account is still bound.

## Why

This unblocks Logos-driven namespace provisioning in pt-pneuma (#132). The Logos team spec knows the namespace name and Istio injection setting, but the team's GitHub service account email is environment-specific (created by pt-corpus) and is not available in Logos state at declaration time.

Without this change, pt-pneuma cannot derive its namespace map from `module.core_helpers.teams` — the arche module would error on the missing required field.

## Changes

- `variables.tofu`: `google_service_account = optional(string, null)`
- `regional/onboarding/variables.tofu`: same change, updated description
- `regional/onboarding/locals.tofu`: filter nulls from `namespace_admin_service_accounts`
- `regional/onboarding/main.tofu`: `kubernetes_role_v1.namespace_admins` filtered to non-null SAs

## Testing

All 6 existing OpenTofu tests pass.

Closes #166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Namespace admin roles are now created only when a Google service account is configured, preventing unnecessary role setup for namespaces without one.
  * Namespace configuration now allows the Google service account field to be left empty, making onboarding more flexible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->