### PR TITLE
Filter null google_service_account values from container_deployer_service_accounts

### DIFF
--- a/locals.tofu
+++ b/locals.tofu
@@ -4,6 +4,7 @@
 locals {
   container_deployer_service_accounts = toset(distinct([
     for k in values(var.namespaces) : k.google_service_account
+    if k.google_service_account != null
   ]))
 
   fleet_host_project_id     = local.is_fleet_host ? var.project : var.gke_fleet_host_project_id


### PR DESCRIPTION
## Summary

The `container_deployer_service_accounts` local builds a set from `var.namespaces[*].google_service_account`. Since `google_service_account` is `optional(string, null)` (added in #167), namespaces without a service account produce a null element in the set.

OpenTofu rejects `for_each` sets containing null values, causing the plan to fail:

```
Error: Invalid for_each argument
The given "for_each" argument value is unsuitable: "for_each" sets must not contain null values.
```

## Fix

Add an `if k.google_service_account != null` guard to the list comprehension so null values are filtered out before `toset()` is called.

## Testing

All 6 existing `tofu test` cases pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service account handling so empty or missing entries are no longer included in the generated list.
  * Reduced the chance of downstream errors caused by `null` values being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->