### PR TITLE
Enable the Kubernetes Gateway API on regional clusters

### DIFF
--- a/regional/main.tofu
+++ b/regional/main.tofu
@@ -99,6 +99,14 @@ resource "google_container_cluster" "this" {
   enable_intranode_visibility = true
   enable_shielded_nodes       = true
 
+  # Enables the Kubernetes Gateway API. GKE installs and manages the Gateway API CRDs on the
+  # cluster; Istio's istiod reconciles Gateway resources with gatewayClassName "istio" against
+  # them. Required for the Istio ingress migration to Gateway API (Gateway / HTTPRoute).
+
+  gateway_api_config {
+    channel = "CHANNEL_STANDARD"
+  }
+
   # If you're using google_container_node_pool objects with no default node pool, you'll need to set this to a value
   # of at least 1, alongside setting remove_default_node_pool to true.
 

--- a/regional/main.tofu
+++ b/regional/main.tofu
@@ -22,13 +22,6 @@ resource "google_container_cluster" "this" {
       # For more control over which auto-upgrades your cluster and its nodes receive, you can enroll it in a release channel.
 
       min_master_version,
-
-      # The GCP API returns enable_components in a different order than configured. The provider treats
-      # this as an ordered list (TypeList) rather than a set, causing a perpetual diff on every plan even
-      # when the actual set of components is unchanged. Ignore until the provider fixes the comparison.
-      # https://github.com/osinfra-io/pt-arche-google-kubernetes-engine/issues/150
-
-      monitoring_config
     ]
   }
 
@@ -152,20 +145,20 @@ resource "google_container_cluster" "this" {
     }
 
     enable_components = [
+      "SYSTEM_COMPONENTS",
       "APISERVER",
-      "CADVISOR",
-      "CONTROLLER_MANAGER",
-      "DAEMONSET",
-      "DCGM",
-      "DEPLOYMENT",
-      "HPA",
-      "JOBSET",
-      "KUBELET",
-      "POD",
       "SCHEDULER",
-      "STATEFULSET",
+      "CONTROLLER_MANAGER",
       "STORAGE",
-      "SYSTEM_COMPONENTS"
+      "HPA",
+      "POD",
+      "DAEMONSET",
+      "DEPLOYMENT",
+      "STATEFULSET",
+      "CADVISOR",
+      "KUBELET",
+      "DCGM",
+      "JOBSET",
     ]
   }
 

--- a/regional/main.tofu
+++ b/regional/main.tofu
@@ -21,7 +21,14 @@ resource "google_container_cluster" "this" {
       # Cluster master version is managed by the release channel. Google upgrades clusters and nodes automatically.
       # For more control over which auto-upgrades your cluster and its nodes receive, you can enroll it in a release channel.
 
-      min_master_version
+      min_master_version,
+
+      # The GCP API returns enable_components in a different order than configured. The provider treats
+      # this as an ordered list (TypeList) rather than a set, causing a perpetual diff on every plan even
+      # when the actual set of components is unchanged. Ignore until the provider fixes the comparison.
+      # https://github.com/osinfra-io/pt-arche-google-kubernetes-engine/issues/150
+
+      monitoring_config
     ]
   }
 

--- a/regional/main.tofu
+++ b/regional/main.tofu
@@ -101,10 +101,15 @@ resource "google_container_cluster" "this" {
 
   # Enables the Kubernetes Gateway API. GKE installs and manages the Gateway API CRDs on the
   # cluster; Istio's istiod reconciles Gateway resources with gatewayClassName "istio" against
-  # them. Required for the Istio ingress migration to Gateway API (Gateway / HTTPRoute).
+  # them. Required for the Istio ingress migration to Gateway API (Gateway / HTTPRoute). Only
+  # enabled on clusters that host Gateway resources (the pneuma gateway clusters).
 
-  gateway_api_config {
-    channel = "CHANNEL_STANDARD"
+  dynamic "gateway_api_config" {
+    for_each = var.enable_gateway_api ? [1] : []
+
+    content {
+      channel = "CHANNEL_STANDARD"
+    }
   }
 
   # If you're using google_container_node_pool objects with no default node pool, you'll need to set this to a value

--- a/regional/variables.tofu
+++ b/regional/variables.tofu
@@ -45,6 +45,12 @@ variable "enable_deletion_protection" {
   type        = bool
 }
 
+variable "enable_gateway_api" {
+  default     = false
+  description = "Whether or not to enable the Kubernetes Gateway API on the cluster"
+  type        = bool
+}
+
 variable "enable_gke_hub_host" {
   default     = false
   description = "Whether or not to enable GKE Hub Host"


### PR DESCRIPTION
Enables the Kubernetes Gateway API on regional GKE clusters via `gateway_api_config { channel = "CHANNEL_STANDARD" }`.

GKE installs and manages the Gateway API CRDs so Istio's istiod can reconcile `Gateway` resources with `gatewayClassName: istio` against them. Required for the Istio ingress migration to the Gateway API.

Part of osinfra-io/pt-pneuma#137.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to enable Kubernetes Gateway API support on the cluster using the standard release channel.
* **Configuration**
  * Introduced a new boolean setting to control whether Gateway API is enabled (default: disabled unless opted in).
* **Bug Fixes**
  * Reduced recurring plan diffs by adjusting the ordering of advanced datapath observability component settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->