### PR TITLE
Sort monitoring enable_components alphabetically to match GCP API order

### DIFF
--- a/regional/main.tofu
+++ b/regional/main.tofu
@@ -145,20 +145,20 @@ resource "google_container_cluster" "this" {
     }
 
     enable_components = [
-      "SYSTEM_COMPONENTS",
       "APISERVER",
-      "SCHEDULER",
-      "CONTROLLER_MANAGER",
-      "STORAGE",
-      "HPA",
-      "POD",
-      "DAEMONSET",
-      "DEPLOYMENT",
-      "STATEFULSET",
       "CADVISOR",
-      "KUBELET",
+      "CONTROLLER_MANAGER",
+      "DAEMONSET",
       "DCGM",
+      "DEPLOYMENT",
+      "HPA",
       "JOBSET",
+      "KUBELET",
+      "POD",
+      "SCHEDULER",
+      "STATEFULSET",
+      "STORAGE",
+      "SYSTEM_COMPONENTS",
     ]
   }
 


### PR DESCRIPTION
Fixes the perpetual diff on `monitoring_config.enable_components` reported in #150.

The GCP API returns `enable_components` in alphabetical order. Because the provider treats this attribute as an ordered list (`TypeList`) rather than a set, any mismatch between the configured order and the API's return order produces a spurious diff on every plan/apply — even though the actual set of components is unchanged.

Sorting the list alphabetically to match the API's return order eliminates the diff without requiring `ignore_changes = [monitoring_config]`, which would suppress legitimate monitoring config changes.

Closes #150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reordered the cluster monitoring component configuration without changing the enabled components or monitoring behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->